### PR TITLE
fix calculation and info on percentage card in dashboard

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,11 +7,9 @@ class PagesController < ApplicationController
   def home
     @balance = @earnings - @spendings
     @balance.negative? ? @color = "text-danger" : @color = "text-black"
-    if @earnings == 0
-      @percentage = ((@spendings / 1) * 100).round
-    else
-      @percentage = ((@spendings / @earnings) * 100).round
-    end
+    return if @earnings.zero?
+
+    @percentage = ((@spendings / @earnings) * 100).round
   end
 
   def new

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -45,7 +45,13 @@
               <div class="progress"
               style="width:<%=@percentage%>%; background: <%=@percentage.to_i > 80 ? "#a93a35" : "#4065c5"%>"></div>
             </div>
-            <p>you have spent <%= @percentage.to_i > 100 ? "#{@percentage -100}% on top of your income" : "#{@percentage}% of your income" %></p>
+            <% if @percentage.nil? %>
+            <p>There is no income information yet 😕</p>
+            <% elsif @percentage.to_i > 100  %>
+            <%= "you have spent #{@percentage - 100}% on top of your income" %>
+            <% else %>
+            <%= "you have spent #{@percentage}% of your income" %>
+            <% end %>
           </div>
         </div>
       <div class="row">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -48,7 +48,7 @@
             <% if @percentage.nil? %>
             <p>There is no income information yet 😕</p>
             <% elsif @percentage.to_i > 100  %>
-            <%= "you have spent #{@percentage - 100}% on top of your income" %>
+            <%= "you spent #{@percentage - 100}% more than your income" %>
             <% else %>
             <%= "you have spent #{@percentage}% of your income" %>
             <% end %>


### PR DESCRIPTION
- Corrected the percentage return when there is no input about user's earnings.  
- Add an if else on pages/home, so the information is shown accordingly.